### PR TITLE
Github build failures

### DIFF
--- a/location/location.go
+++ b/location/location.go
@@ -29,9 +29,13 @@ func UniqueAndSort(locations []string) []string {
 		unique = append(unique, loc)
 	}
 
-	// Sort by the part after the colon
+	// Sort by the part after the colon, with full string as secondary key for ties
 	sort.Slice(unique, func(i, j int) bool {
-		return GetSortKey(unique[i]) < GetSortKey(unique[j])
+		keyI, keyJ := GetSortKey(unique[i]), GetSortKey(unique[j])
+		if keyI == keyJ {
+			return unique[i] < unique[j] // Secondary sort by full string for deterministic ordering
+		}
+		return keyI < keyJ
 	})
 
 	return unique


### PR DESCRIPTION
Add a secondary sort key to `UniqueAndSort` to ensure deterministic ordering and fix intermittent test failures.

The `UniqueAndSort` function previously had non-deterministic behavior when multiple items shared the same primary sort key (the part after the colon), due to Go map iteration order and lack of a tie-breaker. This caused intermittent failures in `TestUniqueAndSort/removes_duplicates`.

---
<a href="https://cursor.com/background-agent?bcId=bc-484ee3f7-560b-44fd-9bd6-767a97c4e415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-484ee3f7-560b-44fd-9bd6-767a97c4e415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting consistency by implementing deterministic ordering for equivalent entries, ensuring stable and predictable result ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->