### PR TITLE
Drag and drop windows issue

### DIFF
--- a/cmd/gui/frontend/app.js
+++ b/cmd/gui/frontend/app.js
@@ -12,15 +12,47 @@ document.addEventListener('DOMContentLoaded', () => {
         selectFile('priorities');
     });
 
-    // Handle Wails file drop events
-    window.runtime?.EventsOn('wails:file-drop', (files) => {
-        if (files && files.length > 0) {
-            const file = files[0];
-            if (file.endsWith('.csv')) {
+    // Handle Wails native file drop events (required for Windows)
+    // The event provides x, y coordinates and files array
+    window.runtime?.EventsOn('wails:file-drop', (x, y, files) => {
+        if (!files || files.length === 0) return;
+        
+        const file = files[0];
+        const locationsZone = document.getElementById('locations-zone');
+        const prioritiesZone = document.getElementById('priorities-zone');
+        
+        // Get element at drop coordinates to determine which zone
+        const dropTarget = document.elementFromPoint(x, y);
+        
+        // Check if drop was on locations zone
+        if (locationsZone.contains(dropTarget) || dropTarget === locationsZone) {
+            if (file.toLowerCase().endsWith('.csv')) {
                 setFile('locations', file);
-            } else if (file.endsWith('.xlsx')) {
-                setFile('priorities', file);
+            } else {
+                showStatus('Please drop a CSV file for locations', 'error');
+                showZoneError('locations');
             }
+            return;
+        }
+        
+        // Check if drop was on priorities zone
+        if (prioritiesZone.contains(dropTarget) || dropTarget === prioritiesZone) {
+            if (file.toLowerCase().endsWith('.xlsx')) {
+                setFile('priorities', file);
+            } else {
+                showStatus('Please drop an XLSX file for priorities', 'error');
+                showZoneError('priorities');
+            }
+            return;
+        }
+        
+        // File dropped outside specific zones - auto-detect by extension
+        if (file.toLowerCase().endsWith('.csv')) {
+            setFile('locations', file);
+        } else if (file.toLowerCase().endsWith('.xlsx')) {
+            setFile('priorities', file);
+        } else {
+            showStatus('Unsupported file type. Please use CSV or XLSX files.', 'error');
         }
     });
 });
@@ -38,20 +70,8 @@ function handleDragLeave(event) {
 function handleDrop(event, type) {
     event.preventDefault();
     event.currentTarget.classList.remove('drag-over');
-    
-    // Get dropped files
-    const files = event.dataTransfer.files;
-    if (files.length > 0) {
-        const file = files[0];
-        // For web file drops, we need to use the Wails backend
-        // The actual path will be handled by Wails file drop event
-    }
-    
-    // Also check for file path in text (from Wails drop)
-    const text = event.dataTransfer.getData('text');
-    if (text) {
-        setFile(type, text);
-    }
+    // On Windows, native file drop is handled by Wails via wails:file-drop event
+    // The webview's dataTransfer doesn't contain proper file paths on Windows
 }
 
 // File selection via dialog

--- a/cmd/gui/frontend/style.css
+++ b/cmd/gui/frontend/style.css
@@ -55,6 +55,7 @@ h1 {
     text-align: center;
     cursor: pointer;
     transition: all 0.2s ease;
+    --drop-target: drop; /* Required for Wails native file drop on Windows */
 }
 
 .drop-zone:hover {

--- a/cmd/gui/main.go
+++ b/cmd/gui/main.go
@@ -30,7 +30,9 @@ func main() {
 		},
 		DragAndDrop: &options.DragAndDrop{
 			EnableFileDrop:     true,
-			DisableWebViewDrop: false,
+			DisableWebViewDrop: true, // Required for Windows - WebView2 doesn't handle native file drops properly
+			CSSDropProperty:    "--drop-target",
+			CSSDropValue:       "drop",
 		},
 	})
 


### PR DESCRIPTION
Enable native file drag and drop on Windows by disabling WebView2's default drop handling and updating the frontend event listener.

WebView2 on Windows does not correctly process native file drops from Explorer, leading to empty or invalid file references in `event.dataTransfer.files`. Setting `DisableWebViewDrop: true` forces Wails to intercept and handle these drops at the OS level, providing correct file paths and coordinates via the `wails:file-drop` event.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bff5f7f-e63c-414a-aef3-b62d6b11b104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bff5f7f-e63c-414a-aef3-b62d6b11b104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

