### PR TITLE
Rules yaml default setup

### DIFF
--- a/cmd/gui/app.go
+++ b/cmd/gui/app.go
@@ -29,6 +29,15 @@ func NewApp() *App {
 // startup is called when the app starts
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
+
+	// Ensure rules.yaml exists in Documents folder on startup
+	// This allows users to configure rules before processing their first file
+	rulesPath, err := config.EnsureDefaultRulesFile()
+	if err != nil {
+		fmt.Printf("Warning: failed to ensure rules file: %v\n", err)
+	} else {
+		fmt.Printf("Rules file location: %s\n", rulesPath)
+	}
 }
 
 // SetLocationsFile sets the locations CSV file path
@@ -86,9 +95,8 @@ func (a *App) Process() (string, error) {
 		return "", fmt.Errorf("no priorities file selected")
 	}
 
-	// Ensure rules.yaml exists in the same directory as locations file
-	rulesDir := filepath.Dir(a.locationsFile)
-	rulesPath, err := config.EnsureRulesFile(rulesDir)
+	// Get rules.yaml from Documents folder
+	rulesPath, err := config.EnsureDefaultRulesFile()
 	if err != nil {
 		return "", fmt.Errorf("failed to ensure rules file: %w", err)
 	}
@@ -109,7 +117,8 @@ func (a *App) Process() (string, error) {
 	)
 
 	// Generate output filename in same directory as locations file
-	outputPath := filepath.Join(rulesDir, "locations_output.xlsx")
+	outputDir := filepath.Dir(a.locationsFile)
+	outputPath := filepath.Join(outputDir, "locations_output.xlsx")
 
 	// Write XLSX output
 	if err := output.WriteXLSX(outputPath, outputData); err != nil {

--- a/cmd/webgui/main.go
+++ b/cmd/webgui/main.go
@@ -43,6 +43,15 @@ func main() {
 	}
 	defer os.RemoveAll(tempDir)
 
+	// Ensure rules.yaml exists in Documents folder on startup
+	// This allows users to configure rules before processing their first file
+	rulesPath, err := config.EnsureDefaultRulesFile()
+	if err != nil {
+		log.Printf("Warning: failed to ensure rules file: %v", err)
+	} else {
+		log.Printf("Rules file location: %s", rulesPath)
+	}
+
 	app := &App{
 		tempDir:      tempDir,
 		shutdownChan: make(chan struct{}),
@@ -255,8 +264,8 @@ func (a *App) handleProcess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure rules.yaml exists in temp directory
-	rulesPath, err := config.EnsureRulesFile(a.tempDir)
+	// Get rules.yaml from Documents folder
+	rulesPath, err := config.EnsureDefaultRulesFile()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to ensure rules file: %v", err), http.StatusInternalServerError)
 		return

--- a/config/config.go
+++ b/config/config.go
@@ -5,12 +5,49 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 //go:embed default_rules.yaml
 var DefaultRulesYAML []byte
 
 const DefaultRulesFileName = "rules.yaml"
+
+// GetDefaultRulesDir returns the default directory for storing rules.yaml
+// This is the user's Documents folder, which is a standard location for user configuration
+func GetDefaultRulesDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	// Use Documents folder on all platforms
+	var documentsDir string
+	switch runtime.GOOS {
+	case "windows":
+		// On Windows, Documents is typically under the user profile
+		documentsDir = filepath.Join(homeDir, "Documents")
+	default:
+		// On macOS and Linux, use ~/Documents
+		documentsDir = filepath.Join(homeDir, "Documents")
+	}
+
+	// Ensure the Documents directory exists
+	if err := os.MkdirAll(documentsDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create documents directory: %w", err)
+	}
+
+	return documentsDir, nil
+}
+
+// GetDefaultRulesPath returns the full path to the default rules.yaml location
+func GetDefaultRulesPath() (string, error) {
+	dir, err := GetDefaultRulesDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, DefaultRulesFileName), nil
+}
 
 // EnsureRulesFile checks if rules.yaml exists, creates it from embedded default if not
 // Returns the path to the rules file
@@ -27,6 +64,16 @@ func EnsureRulesFile(dir string) (string, error) {
 	}
 
 	return rulesPath, nil
+}
+
+// EnsureDefaultRulesFile ensures rules.yaml exists in the default Documents location
+// Returns the path to the rules file
+func EnsureDefaultRulesFile() (string, error) {
+	dir, err := GetDefaultRulesDir()
+	if err != nil {
+		return "", err
+	}
+	return EnsureRulesFile(dir)
 }
 
 // GetRulesPath returns the path to rules.yaml in the given directory


### PR DESCRIPTION
Move `rules.yaml` to the `Documents` folder and create it on app launch to provide a consistent, user-configurable setup before first use.

Previously, `rules.yaml` was generated upon the first document processing, often in the input file's directory or a temporary location. This PR ensures `rules.yaml` is created in the user's `Documents` folder when the app launches, allowing users to configure their rules before processing any files and providing a predictable location for user-managed settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbd15fe0-00f3-4e91-bddb-2bff2a91a312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbd15fe0-00f3-4e91-bddb-2bff2a91a312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now automatically ensures a default rules file exists in a standard location on startup, with appropriate error handling and logging
  * Output files are now placed alongside the input file instead of the rules directory

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->