### PR TITLE
Spillover GUI CLI issue

### DIFF
--- a/cmd/webgui/frontend/app.js
+++ b/cmd/webgui/frontend/app.js
@@ -1,13 +1,16 @@
 // State
 let locationsFile = '';
 let prioritiesFile = '';
+let rulesFile = '';
 
 // Initialize
 document.addEventListener('DOMContentLoaded', () => {
     const locationsZone = document.getElementById('locations-zone');
     const prioritiesZone = document.getElementById('priorities-zone');
+    const rulesZone = document.getElementById('rules-zone');
     const locationsInput = document.getElementById('locations-input');
     const prioritiesInput = document.getElementById('priorities-input');
+    const rulesInput = document.getElementById('rules-input');
 
     // Click to browse - Locations
     locationsZone.addEventListener('click', () => {
@@ -17,6 +20,11 @@ document.addEventListener('DOMContentLoaded', () => {
     // Click to browse - Priorities
     prioritiesZone.addEventListener('click', () => {
         prioritiesInput.click();
+    });
+
+    // Click to browse - Rules
+    rulesZone.addEventListener('click', () => {
+        rulesInput.click();
     });
 
     // File input change handlers
@@ -32,11 +40,20 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    rulesInput.addEventListener('change', (e) => {
+        if (e.target.files.length > 0) {
+            uploadFile(e.target.files[0], 'rules');
+        }
+    });
+
     // Drag and drop - Locations
-    setupDropZone(locationsZone, 'locations', '.csv');
+    setupDropZone(locationsZone, 'locations', ['.csv']);
     
     // Drag and drop - Priorities
-    setupDropZone(prioritiesZone, 'priorities', '.xlsx');
+    setupDropZone(prioritiesZone, 'priorities', ['.xlsx']);
+
+    // Drag and drop - Rules (accepts .yaml and .yml)
+    setupDropZone(rulesZone, 'rules', ['.yaml', '.yml']);
 
     // Prevent default drag behavior on document
     document.addEventListener('dragover', (e) => e.preventDefault());
@@ -44,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // Set up drag and drop for a zone
-function setupDropZone(zone, type, extension) {
+function setupDropZone(zone, type, extensions) {
     zone.addEventListener('dragover', (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -66,9 +83,12 @@ function setupDropZone(zone, type, extension) {
         if (files.length > 0) {
             const file = files[0];
             
-            // Check file extension
-            if (!file.name.toLowerCase().endsWith(extension)) {
-                showStatus(`Please drop a ${extension.toUpperCase().slice(1)} file for ${type}`, 'error');
+            // Check file extension (supports multiple extensions)
+            const fileName = file.name.toLowerCase();
+            const validExtension = extensions.some(ext => fileName.endsWith(ext));
+            if (!validExtension) {
+                const extList = extensions.map(e => e.toUpperCase().slice(1)).join('/');
+                showStatus(`Please drop a ${extList} file for ${type}`, 'error');
                 showZoneError(type);
                 return;
             }
@@ -87,7 +107,12 @@ async function uploadFile(file, type) {
         const formData = new FormData();
         formData.append('file', file);
 
-        const endpoint = type === 'locations' ? '/api/upload-locations' : '/api/upload-priorities';
+        const endpoints = {
+            'locations': '/api/upload-locations',
+            'priorities': '/api/upload-priorities',
+            'rules': '/api/upload-rules'
+        };
+        const endpoint = endpoints[type];
         
         const response = await fetch(endpoint, {
             method: 'POST',
@@ -120,8 +145,10 @@ function updateFileDisplay(type, filename) {
     
     if (type === 'locations') {
         locationsFile = filename;
-    } else {
+    } else if (type === 'priorities') {
         prioritiesFile = filename;
+    } else if (type === 'rules') {
+        rulesFile = filename;
     }
     
     updateOkButton();
@@ -148,15 +175,19 @@ async function resetFiles() {
         
         locationsFile = '';
         prioritiesFile = '';
+        rulesFile = '';
         
         document.getElementById('locations-file').textContent = '';
         document.getElementById('priorities-file').textContent = '';
+        document.getElementById('rules-file').textContent = '';
         document.getElementById('locations-zone').classList.remove('has-file', 'error');
         document.getElementById('priorities-zone').classList.remove('has-file', 'error');
+        document.getElementById('rules-zone').classList.remove('has-file', 'error');
         
         // Reset file inputs
         document.getElementById('locations-input').value = '';
         document.getElementById('priorities-input').value = '';
+        document.getElementById('rules-input').value = '';
         
         updateOkButton();
         clearStatus();

--- a/cmd/webgui/frontend/index.html
+++ b/cmd/webgui/frontend/index.html
@@ -29,6 +29,17 @@
             </div>
         </div>
         
+        <div class="optional-section">
+            <div class="optional-label">Optional: Custom Rules</div>
+            <div class="drop-zone drop-zone-small" id="rules-zone">
+                <div class="drop-icon">⚙️</div>
+                <div class="drop-label">Rules YAML</div>
+                <div class="drop-hint">Drop .yaml file (optional - controls column size)</div>
+                <div class="file-name" id="rules-file"></div>
+                <input type="file" id="rules-input" accept=".yaml,.yml" style="display: none">
+            </div>
+        </div>
+        
         <div class="status" id="status"></div>
         
         <div class="buttons">

--- a/cmd/webgui/frontend/style.css
+++ b/cmd/webgui/frontend/style.css
@@ -47,6 +47,38 @@ h1 {
     margin-bottom: 20px;
 }
 
+.optional-section {
+    margin-bottom: 20px;
+}
+
+.optional-label {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+.drop-zone-small {
+    min-height: 100px;
+    padding: 16px;
+}
+
+.drop-zone-small .drop-icon {
+    font-size: 28px;
+    margin-bottom: 8px;
+}
+
+.drop-zone-small .drop-label {
+    font-size: 14px;
+    margin-bottom: 4px;
+}
+
+.drop-zone-small .drop-hint {
+    font-size: 11px;
+}
+
 .drop-zone {
     background: rgba(255, 255, 255, 0.08);
     border: 2px dashed rgba(255, 255, 255, 0.3);

--- a/cmd/webgui/main.go
+++ b/cmd/webgui/main.go
@@ -30,6 +30,7 @@ var frontendFS embed.FS
 type App struct {
 	locationsFile  string
 	prioritiesFile string
+	rulesFile      string // Optional custom rules.yaml
 	tempDir        string
 	server         *http.Server
 	shutdownChan   chan struct{}
@@ -65,6 +66,7 @@ func main() {
 	// API endpoints
 	mux.HandleFunc("/api/upload-locations", app.handleUploadLocations)
 	mux.HandleFunc("/api/upload-priorities", app.handleUploadPriorities)
+	mux.HandleFunc("/api/upload-rules", app.handleUploadRules)
 	mux.HandleFunc("/api/process", app.handleProcess)
 	mux.HandleFunc("/api/reset", app.handleReset)
 	mux.HandleFunc("/api/status", app.handleStatus)
@@ -239,6 +241,55 @@ func (a *App) handleUploadPriorities(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleUploadRules handles uploading an optional custom rules.yaml file
+func (a *App) handleUploadRules(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Parse multipart form (max 1 MB for YAML)
+	if err := r.ParseMultipartForm(1 << 20); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to parse form: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to get file: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+
+	// Validate file extension
+	if !strings.HasSuffix(strings.ToLower(header.Filename), ".yaml") && !strings.HasSuffix(strings.ToLower(header.Filename), ".yml") {
+		http.Error(w, "Rules file must be a YAML file (.yaml or .yml)", http.StatusBadRequest)
+		return
+	}
+
+	// Save to temp directory as rules.yaml
+	destPath := filepath.Join(a.tempDir, "rules.yaml")
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to create file: %v", err), http.StatusInternalServerError)
+		return
+	}
+	defer destFile.Close()
+
+	if _, err := io.Copy(destFile, file); err != nil {
+		http.Error(w, fmt.Sprintf("Failed to save file: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	a.rulesFile = destPath
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"success":  true,
+		"filename": header.Filename,
+	})
+}
+
 // handleProcess processes the files and generates output
 func (a *App) handleProcess(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -255,11 +306,17 @@ func (a *App) handleProcess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure rules.yaml exists in temp directory
-	rulesPath, err := config.EnsureRulesFile(a.tempDir)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to ensure rules file: %v", err), http.StatusInternalServerError)
-		return
+	// Use custom rules.yaml if uploaded, otherwise create default
+	var rulesPath string
+	if a.rulesFile != "" {
+		rulesPath = a.rulesFile
+	} else {
+		var err error
+		rulesPath, err = config.EnsureRulesFile(a.tempDir)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to ensure rules file: %v", err), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Process the data
@@ -331,9 +388,13 @@ func (a *App) handleReset(w http.ResponseWriter, r *http.Request) {
 	if a.prioritiesFile != "" {
 		os.Remove(a.prioritiesFile)
 	}
+	if a.rulesFile != "" {
+		os.Remove(a.rulesFile)
+	}
 
 	a.locationsFile = ""
 	a.prioritiesFile = ""
+	a.rulesFile = ""
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{"success": true})
@@ -343,6 +404,7 @@ func (a *App) handleReset(w http.ResponseWriter, r *http.Request) {
 func (a *App) handleStatus(w http.ResponseWriter, r *http.Request) {
 	locationsName := ""
 	prioritiesName := ""
+	rulesName := ""
 	
 	if a.locationsFile != "" {
 		locationsName = filepath.Base(a.locationsFile)
@@ -350,11 +412,15 @@ func (a *App) handleStatus(w http.ResponseWriter, r *http.Request) {
 	if a.prioritiesFile != "" {
 		prioritiesName = filepath.Base(a.prioritiesFile)
 	}
+	if a.rulesFile != "" {
+		rulesName = filepath.Base(a.rulesFile)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"locationsFile":  locationsName,
 		"prioritiesFile": prioritiesName,
+		"rulesFile":      rulesName,
 	})
 }
 


### PR DESCRIPTION
Add support for custom `rules.yaml` upload in the WebGUI.

The WebGUI previously always used a default `rules.yaml` configuration, preventing users from customizing spillover `size` and `gap` parameters. This change allows users to upload their own `rules.yaml` to control these settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc178ae2-e5d5-44b9-ac3b-ab1a9cd3d6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc178ae2-e5d5-44b9-ac3b-ab1a9cd3d6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Users can now upload custom YAML rules files (.yaml, .yml formats supported)
  * System uses custom rules when provided, otherwise falls back to defaults
  * New "Optional: Custom Rules" section added to the interface

* **UI/Style Improvements**
  * Introduced compact drop zone for rules file uploads
  * Added styling for optional configuration sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->