### PR TITLE
Empty groups excel output

### DIFF
--- a/output/csv.go
+++ b/output/csv.go
@@ -20,9 +20,13 @@ func WriteCSV(filePath string, data *OutputData) error {
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
 
-	// Build group titles (titles + unassigned if it has items)
+	// Build group titles (only including groups that have items)
 	groupTitles := make([]string, 0, len(data.TitleOrder)+1)
-	groupTitles = append(groupTitles, data.TitleOrder...)
+	for _, title := range data.TitleOrder {
+		if len(data.Grouped[title]) > 0 {
+			groupTitles = append(groupTitles, title)
+		}
+	}
 	if len(data.Grouped["unassigned"]) > 0 {
 		groupTitles = append(groupTitles, "unassigned")
 	}

--- a/output/csv_test.go
+++ b/output/csv_test.go
@@ -160,6 +160,57 @@ func TestWriteCSV_SpilloverLayout(t *testing.T) {
 	}
 }
 
+func TestWriteCSV_EmptyGroupsOmitted(t *testing.T) {
+	// Test that empty groups are not included in the output
+	grouped := rules.TitleGroupedLocations{
+		"Pallets":   []string{},                    // Empty - should be omitted
+		"Shelves":   []string{"S1", "S2", "S3"},    // Has items - should be included
+		"FloorLocs": []string{},                    // Empty - should be omitted
+		"Bins":      []string{"B1", "B2"},          // Has items - should be included
+	}
+
+	// TitleOrder includes all groups, but empty ones should be skipped
+	data := NewOutputData([]string{"Pallets", "Shelves", "FloorLocs", "Bins"}, grouped, nil, 1, 0)
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.csv")
+	if err := WriteCSV(filePath, data); err != nil {
+		t.Fatalf("WriteCSV failed: %v", err)
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to read CSV: %v", err)
+	}
+
+	// Header should be: Shelves, "", Bins (gap=1 between groups)
+	header := records[0]
+	expectedHeaders := []string{"Shelves", "", "Bins"}
+	if len(header) != len(expectedHeaders) {
+		t.Fatalf("got %d columns, want %d: %v", len(header), len(expectedHeaders), header)
+	}
+
+	for i, want := range expectedHeaders {
+		if header[i] != want {
+			t.Errorf("header[%d] = %q, want %q", i, header[i], want)
+		}
+	}
+
+	// Verify "Pallets" and "FloorLocs" are NOT in the output
+	for _, h := range header {
+		if h == "Pallets" || h == "FloorLocs" {
+			t.Errorf("empty group %q should not be in output", h)
+		}
+	}
+}
+
 func TestWriteCSV_GapColumns(t *testing.T) {
 	grouped := rules.TitleGroupedLocations{
 		"GroupA": []string{"A1", "A2"},

--- a/output/xlsx.go
+++ b/output/xlsx.go
@@ -38,9 +38,13 @@ func WriteXLSX(filePath string, data *OutputData) error {
 		return fmt.Errorf("failed to create priority style: %w", err)
 	}
 
-	// Build group titles (titles + unassigned if it has items)
+	// Build group titles (only including groups that have items)
 	groupTitles := make([]string, 0, len(data.TitleOrder)+1)
-	groupTitles = append(groupTitles, data.TitleOrder...)
+	for _, title := range data.TitleOrder {
+		if len(data.Grouped[title]) > 0 {
+			groupTitles = append(groupTitles, title)
+		}
+	}
 	if len(data.Grouped["unassigned"]) > 0 {
 		groupTitles = append(groupTitles, "unassigned")
 	}

--- a/output/xlsx_test.go
+++ b/output/xlsx_test.go
@@ -192,6 +192,62 @@ func TestWriteXLSX_ColumnWidth(t *testing.T) {
 	}
 }
 
+func TestWriteXLSX_EmptyGroupsOmitted(t *testing.T) {
+	// Test that empty groups are not included in the output
+	grouped := rules.TitleGroupedLocations{
+		"Pallets":   []string{},                    // Empty - should be omitted
+		"Shelves":   []string{"S1", "S2", "S3"},    // Has items - should be included
+		"FloorLocs": []string{},                    // Empty - should be omitted
+		"Bins":      []string{"B1", "B2"},          // Has items - should be included
+	}
+
+	// TitleOrder includes all groups, but empty ones should be skipped
+	data := NewOutputData([]string{"Pallets", "Shelves", "FloorLocs", "Bins"}, grouped, nil, 1, 0)
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.xlsx")
+	if err := WriteXLSX(filePath, data); err != nil {
+		t.Fatalf("WriteXLSX failed: %v", err)
+	}
+
+	f, err := excelize.OpenFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer f.Close()
+
+	sheetName := "Locations"
+
+	// Collect all header values from row 1
+	headers := make([]string, 0)
+	for col := 1; col <= 20; col++ {
+		cell, _ := excelize.CoordinatesToCellName(col, 1)
+		val, _ := f.GetCellValue(sheetName, cell)
+		if val != "" {
+			headers = append(headers, val)
+		}
+	}
+
+	// Should only have "Shelves" and "Bins" headers (empty groups omitted)
+	expectedHeaders := []string{"Shelves", "Bins"}
+	if len(headers) != len(expectedHeaders) {
+		t.Errorf("expected %d headers, got %d: %v", len(expectedHeaders), len(headers), headers)
+	}
+
+	for i, want := range expectedHeaders {
+		if i < len(headers) && headers[i] != want {
+			t.Errorf("header %d: got %q, want %q", i, headers[i], want)
+		}
+	}
+
+	// Verify "Pallets" and "FloorLocs" are NOT in the output
+	for _, h := range headers {
+		if h == "Pallets" || h == "FloorLocs" {
+			t.Errorf("empty group %q should not be in output", h)
+		}
+	}
+}
+
 func TestWriteXLSX_PriorityHighlight(t *testing.T) {
 	grouped := rules.TitleGroupedLocations{
 		"Group": []string{"item1", "item2", "item3"},


### PR DESCRIPTION
Omit empty groups from Excel and CSV output to prevent them from appearing in the final files.

---
<a href="https://cursor.com/background-agent?bcId=bc-06b378ef-db7f-4986-ad4d-dd9a0d926d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06b378ef-db7f-4986-ad4d-dd9a0d926d4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV and XLSX exports now omit empty group columns from output headers, resulting in cleaner files with only non-empty groups displayed.

* **Tests**
  * Added regression tests to verify empty groups are properly excluded from exported files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->